### PR TITLE
ClearImage Improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /Map Editor/bin/Release
 /Map Editor/obj/Release
 /.vs/Map Editor
+/.vs
+/Map Editor/bin
+/Map Editor/obj

--- a/Map Editor/Main.cs
+++ b/Map Editor/Main.cs
@@ -1054,8 +1054,25 @@ namespace Map_Editor
         {
             for (var i = 0; i < Libraries.MapLibs.Length; i++)
             {
+                if (Libraries.MapLibs[i] == null) continue;
+
                 for (var j = 0; j < Libraries.MapLibs[i].Images.Count; j++)
                 {
+                    var mImage = Libraries.MapLibs[i].Images[j];
+                    if (mImage == null) continue;
+
+                    if (mImage.Image != null)
+                    {
+                        mImage.Image.Dispose();
+                        mImage.Image = null;
+                    }
+
+                    if (mImage.ImageTexture != null && !mImage.ImageTexture.Disposed)
+                    {
+                        mImage.ImageTexture.Dispose();
+                        mImage.ImageTexture = null;
+                    }
+
                     Libraries.MapLibs[i].Images[j] = null;
                 }
             }


### PR DESCRIPTION
This now clears the previous map's data when changing map via TreeBroswer/OpenDiag.

Stops RAM usage going to 100% and crashing the program.

Also adjusted gitignore to not include bin / obj / .vs